### PR TITLE
Switch build system to cabal v2

### DIFF
--- a/COMPILING
+++ b/COMPILING
@@ -1,30 +1,15 @@
-# on ubuntu14.04 (trusty) and later
+# Building Pioneers
 
-just run 
-> ./build.sh
+Install SDL libraries (Ubuntu 14.04 or later):
 
-# manual installation
+    sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev
 
-set up external dependencies:
+The project now uses cabal's v2-style commands with a `cabal.project` file. You can build either with cabal or stack:
 
-> sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev
-> cd deps && ./getDeps.sh && cd ..
+    cabal v2-build
 
-NOTE: ubuntu saucy currently only has libsdl2-dev.2.0.0 in the repositories, but we need libsdl2-dev.2.0.1
-      Therefore the update-script gets the updated packages for trusty (which have the same dependencies)
-      and installs them.
-      PIONEERS WONT RUN WITH VERSION 2.0.0 OF LIBSDL2!
+or
 
-make sure the compiled files are in your PATH (e.g. include $HOME/.cabal/bin in your $PATH)
+    stack build
 
-install dependencies & configure app
-> cabal sandbox init
-> cabal sandbox add-source deps/hsSDL2
-> cabal sandbox add-source deps/hsSDL2-ttf
-> cabal install --only-dependencies
-> cabal configure
-
-build
-> cabal build
-
-run ./Pioneers (symlinked to dist/build/Pioneers/Pioneers)
+A helper script `build.sh` is provided which simply runs `cabal v2-build`.

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-cabal sandbox init
+set -e
 
-cd deps
-./getDeps.sh
-cd ..
-
-cabal sandbox add-source deps/hsSDL2
-cabal sandbox add-source deps/hsSDL2-ttf
-cabal install --only-dependencies
-cabal configure
-cabal build
+cabal v2-update
+cabal v2-build

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,17 @@
+packages: .
+
+source-repository-package
+  type: git
+  location: https://github.com/Lemmih/hsSDL2
+
+source-repository-package
+  type: git
+  location: https://github.com/osa1/hsSDL2-ttf
+
+source-repository-package
+  type: git
+  location: https://github.com/jdeseno/hs-sdl2-mixer
+
+source-repository-package
+  type: git
+  location: https://github.com/jdeseno/hs-sdl2-image

--- a/deps/getDeps.sh
+++ b/deps/getDeps.sh
@@ -1,84 +1,8 @@
 #!/bin/bash
+set -e
 
-if [ "$1" != "ni" ]
-then
-        if [ ! -f /usr/bin/dialog ]
-	then
-		sudo apt-get install dialog
-	fi
-        dialog --yesno "Install libSDL2 from ubuntu trusty repositories?\n\nSAUCY IS NOT SUPPORTED! You NEED Ubuntu 14.04+\n\nThe script will try to install the trusty-packages." 20 75
-	install=${?}
-else
-	install=0
+if [ "$1" != "ni" ]; then
+    sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev
 fi
 
-if [[ $install -eq 0 ]]
-then
-	sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev
-fi
-
-
-
-echo "cloning repositories"
-if [ ! -d "hsSDL2" ]
-then
-	git clone https://github.com/Lemmih/hsSDL2 hsSDL2
-else
-	cd hsSDL2
-	git pull
-	cd ..
-fi
-
-if [ ! -d "hsSDL2-ttf" ]
-then
-	git clone https://github.com/osa1/hsSDL2-ttf hsSDL2-ttf
-else
-	cd hsSDL2-ttf
-	git pull
-	cd ..
-fi
-
-if [ ! -d "hsSDL2-mixer" ]
-then
-	git clone https://github.com/jdeseno/hs-sdl2-mixer hsSDL2-mixer
-else
-	cd hsSDL2-mixer
-	git pull
-	cd ..
-fi
-
-if [ ! -d "hsSDL2-image" ]
-then
-	git clone https://github.com/jdeseno/hs-sdl2-image hsSDL2-image
-else
-	cd hsSDL2-image
-	git pull
-	cd ..
-fi
-
-
-echo "trying to build"
-
-cabal install haddock
-
-echo "building hsSDL2.."
-
-cd hsSDL2
-cabal sandbox delete
-cabal sandbox init
-cabal install --only-dependencies
-cabal build
-cd ..
-
-for t in "hsSDL2-ttf" "hsSDL2-mixer" "hsSDL2-image"
-do
-	echo "building ${t}.."
-	cd "${t}"
-	cabal sandbox delete
-	cabal sandbox init
-	cabal sandbox add-source ../hsSDL2
-	cabal install --only-dependencies
-	cabal build
-	cd ..
-done
-
+echo "Dependencies will be fetched automatically by cabal v2-build using cabal.project"


### PR DESCRIPTION
## Summary
- modernise build scripts
- rely on cabal v2-style builds
- document new build instructions

## Testing
- `cabal v2-build` *(fails: repository requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_6844b03166a48333a56291bcc3964568